### PR TITLE
Fix directory names with spaces failing to open

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,9 +117,13 @@ async fn list_files(app: tauri::AppHandle, device_id: String, path: String) -> R
     let shell = app.shell();
     let adb_cmd = get_adb_command();
 
+    // Escape single quotes in path and wrap in quotes to handle spaces
+    let escaped_path = path.replace("'", "'\\''");
+    let shell_command = format!("ls -la '{}'", escaped_path);
+
     let output = shell
         .command(&adb_cmd)
-        .args(["-s", &device_id, "shell", "ls", "-la", &path])
+        .args(["-s", &device_id, "shell", &shell_command])
         .output()
         .await
         .map_err(|e| format!("Failed to execute adb command: {}", e))?;


### PR DESCRIPTION
## Summary

Fixes #1 - Properly handles directory and file names containing spaces when navigating through the Android device file system.

## Problem

Previously, when users double-clicked on a directory with spaces in its name (e.g., "AI Edits"), the app would fail with an error:
```
Failed to list files: ADB ls command failed: ls: /path/to/AI: No such file or directory ls: Edits: No such file or directory
```

This occurred because the path was being passed as separate arguments to the ADB shell command, causing the shell to interpret "AI Edits" as two separate paths: "AI" and "Edits".

## Solution

The fix properly escapes and quotes paths when passing them to the adb shell command:
- Escapes single quotes in paths using shell escaping (`'` becomes `'\''`)
- Wraps the entire path in single quotes in the shell command
- Passes the complete shell command as a single argument to adb

## Changes

**Modified:** `src-tauri/src/lib.rs` (lines 120-126)
- Added path escaping logic before constructing the adb command
- Changed from passing path as separate arg to passing as part of shell command string

## Testing

- ✅ Rust backend compiles successfully
- ✅ TypeScript frontend builds successfully
- ✅ Handles spaces in directory names: `"AI Edits"` → `'AI Edits'`
- ✅ Handles single quotes: `"User's Files"` → `'User'\''s Files'`
- ✅ Handles multiple spaces correctly

## Edge Cases Covered

- Simple spaces: `AI Edits`
- Single quotes in names: `User's Files`
- Multiple consecutive spaces: `A  B`
- Mixed special characters with spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)