### PR TITLE
Standardize identifier to rajivm1991

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "droiddock"
 version = "0.1.0"
 description = "macOS app for browsing Android device files via ADB"
-authors = ["rajiv"]
+authors = ["rajivm1991"]
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "DroidDock",
   "version": "0.1.0",
-  "identifier": "com.rajiv.droiddock",
+  "identifier": "com.rajivm1991.droiddock",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Updates bundle identifier and author field to use consistent 'rajivm1991' identifier, matching GitHub username. This ensures consistency
  before first release.