### PR TITLE
fix: correct screenshot paths in landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,23 +117,23 @@
             <h3 class="text-3xl font-bold text-center mb-8 text-gray-800">Screenshots</h3>
             <div class="grid md:grid-cols-2 gap-8">
                 <div>
-                    <img src="../screenshots/main-interface.png" alt="DroidDock Main Interface" class="screenshot w-full">
+                    <img src="screenshots/main-interface.png" alt="DroidDock Main Interface" class="screenshot w-full">
                     <p class="text-center mt-3 text-gray-600">Main file browser interface</p>
                 </div>
                 <div>
-                    <img src="../screenshots/file-list.png" alt="DroidDock File List" class="screenshot w-full">
+                    <img src="screenshots/file-list.png" alt="DroidDock File List" class="screenshot w-full">
                     <p class="text-center mt-3 text-gray-600">Detailed file list view</p>
                 </div>
                 <div>
-                    <img src="../screenshots/features.png" alt="DroidDock Features" class="screenshot w-full">
+                    <img src="screenshots/features.png" alt="DroidDock Features" class="screenshot w-full">
                     <p class="text-center mt-3 text-gray-600">Advanced features and tools</p>
                 </div>
                 <div>
-                    <img src="../screenshots/dark-mode.png" alt="DroidDock Dark Mode" class="screenshot w-full">
+                    <img src="screenshots/dark-mode.png" alt="DroidDock Dark Mode" class="screenshot w-full">
                     <p class="text-center mt-3 text-gray-600">Beautiful dark mode</p>
                 </div>
                 <div class="md:col-span-2 max-w-2xl mx-auto">
-                    <img src="../screenshots/grid-view.png" alt="DroidDock Grid View" class="screenshot w-full">
+                    <img src="screenshots/grid-view.png" alt="DroidDock Grid View" class="screenshot w-full">
                     <p class="text-center mt-3 text-gray-600">Grid view with image previews</p>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Fix screenshot paths from `../screenshots/` to `screenshots/` to display correctly on GitHub Pages

## Issue
The landing page at https://rajivm1991.github.io/DroidDock/ was not showing screenshots because the paths were incorrect.

## Fix
Changed all screenshot image paths from relative parent directory (`../screenshots/`) to relative same directory (`screenshots/`) since both `index.html` and the `screenshots/` folder are in the `docs/` directory.

## Test plan
- [x] Verify screenshot paths are correct
- [ ] Merge PR and confirm screenshots display on GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)