### PR TITLE
feat: add scrollbar to keyboard shortcuts popup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -874,6 +874,9 @@ tbody tr {
   grid-template-columns: repeat(2, 1fr);
   gap: 24px;
   margin-bottom: 24px;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 8px;
 }
 
 .shortcuts-section h4 {


### PR DESCRIPTION
## Summary
- Add scrollbar to keyboard shortcuts popup for better UX as the shortcuts list grows

## Changes
- Added `max-height: 60vh` to limit popup height
- Added `overflow-y: auto` for vertical scrolling
- Added `padding-right: 8px` for better spacing

## Test plan
- [ ] Open keyboard shortcuts popup (Cmd+/)
- [ ] Verify scrollbar appears when content exceeds 60% viewport height

🤖 Generated with [Claude Code](https://claude.com/claude-code)