### PR TITLE
fix: use git tag in release workflow, bump package.json to v0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,24 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Get version
-        run: echo "PACKAGE_VERSION=$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
-
       - name: Create release
         id: create-release
         uses: actions/github-script@v7
         with:
           script: |
+            const tag = context.ref.replace('refs/tags/', '')
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${process.env.PACKAGE_VERSION}`,
-              name: `DroidDock v${process.env.PACKAGE_VERSION}`,
+              tag_name: tag,
+              name: `DroidDock ${tag}`,
               body: `See [CHANGELOG.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CHANGELOG.md) for details.`,
               draft: true,
               prerelease: false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "droiddock",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- **Root cause**: The release workflow read version from `package.json` to name the GitHub release. The `v0.4.0` tag pointed to a commit where `package.json` still said `0.3.0`, causing the workflow to target the v0.3.0 release and fail with `tag_name already_exists`.
- **Fix**: Derive the release tag name directly from `context.ref` (the pushed git tag), removing the `package.json` dependency entirely from the `create-release` job.
- **Bump**: `package.json` version updated from `0.3.0` → `0.4.0` to match current state.

## Changes

- `.github/workflows/release.yml`: Remove `Setup Node` + `Get version` steps from `create-release` job; use `context.ref.replace('refs/tags/', '')` for the tag name
- `package.json`: `version` bumped to `0.4.0`

## Test plan

- [ ] Verify workflow lints cleanly
- [ ] On next tag push (e.g. `v0.5.0`), confirm create-release uses the git tag name, not `package.json` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)