### PR TITLE
feat: add workflow_dispatch to release workflow for rebuilding assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build and release (e.g. v0.3.0)'
+        required: true
 
 env:
   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -19,13 +24,32 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - name: Create release
+      - name: Create or get release
         id: create-release
         uses: actions/github-script@v7
         with:
           script: |
-            const tag = context.ref.replace('refs/tags/', '')
+            const tag = context.eventName === 'workflow_dispatch'
+              ? context.payload.inputs.tag
+              : context.ref.replace('refs/tags/', '')
+
+            // Check if release already exists
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag
+              })
+              console.log(`Found existing release for ${tag}: ${data.id}`)
+              return data.id
+            } catch (e) {
+              if (e.status !== 404) throw e
+            }
+
+            // Create new draft release
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -49,6 +73,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Adds a manual trigger (`workflow_dispatch`) to the release workflow with a `tag` input
- `create-release` job now checks if a release already exists for the tag before creating one — finds it and reuses the id, creates a new draft if not
- Both `create-release` and `build-tauri` checkout the correct ref whether triggered by tag push or manual dispatch

## How to rebuild missing assets (e.g. v0.3.0)

1. Go to **Actions → Release → Run workflow**
2. Enter `v0.3.0` in the tag field
3. The workflow finds the existing release, builds the universal DMG at that tag's commit, uploads the asset, and ensures the release is published

## Test plan

- [ ] Merge and trigger manually with `v0.3.0` to verify assets are uploaded correctly
- [ ] Push a new tag to verify normal tag-push flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)